### PR TITLE
Remove unnecessary flag from getPackageInfo

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -81,7 +81,7 @@ public abstract class ShareIntent {
     protected boolean isPackageInstalled(String packagename, Context context) {
         PackageManager pm = context.getPackageManager();
         try {
-            pm.getPackageInfo(packagename, PackageManager.GET_ACTIVITIES);
+            pm.getPackageInfo(packagename, 0);
             return true;
         } catch (PackageManager.NameNotFoundException e) {
             return false;


### PR DESCRIPTION
According to https://stackoverflow.com/questions/24253976/android-package-manager-has-died-with-transactiontoolargeexception the `Fatal Exception: java.lang.RuntimeException Package manager has died in android.app.ApplicationPackageManager.getPackageInfo` can occur when too much information about too many apps is requested. Removing this flag should decrease the number of crashes.