### PR TITLE
Use localIdentifier to share rather than deprecated AssetPath

### DIFF
--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -25,7 +25,8 @@
     NSURL * shareURL;
     // Instagram doesn't allow sharing videos longer than 60 seconds on iOS anymore. (next button is not responding, trim is unavailable)
     if (videoDurationSeconds <= 60.0f) {
-        NSString * urlString = [NSString stringWithFormat:@"instagram://library?AssetPath=%@", options[@"url"]];
+        NSString * localIdentifier = [options[@"url"] stringByReplacingOccurrencesOfString:@"ph://" withString:@""];
+        NSString * urlString = [NSString stringWithFormat:@"instagram://library?LocalIdentifier=%@", localIdentifier];
         shareURL = [NSURL URLWithString:urlString];
     } else {
         shareURL = [NSURL URLWithString:@"instagram://camera"];


### PR DESCRIPTION
As per undocumented https://stackoverflow.com/a/35099786