### PR TITLE
Fix warnings + crash

### DIFF
--- a/ios/EmailShare.h
+++ b/ios/EmailShare.h
@@ -51,5 +51,5 @@
 #import <MessageUI/MessageUI.h>
 @interface EmailShare : NSObject <MFMailComposeViewControllerDelegate>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/GenericShare.h
+++ b/ios/GenericShare.h
@@ -51,5 +51,5 @@
 #endif
 @interface GenericShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType;
 @end

--- a/ios/GooglePlusShare.h
+++ b/ios/GooglePlusShare.h
@@ -48,5 +48,5 @@
 #endif
 @interface GooglePlusShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/InstagramShare.h
+++ b/ios/InstagramShare.h
@@ -48,5 +48,5 @@
 #endif
 @interface InstagramShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/InstagramStoriesShare.h
+++ b/ios/InstagramStoriesShare.h
@@ -48,5 +48,5 @@
 #endif
 @interface InstagramStoriesShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/MessagesShare.h
+++ b/ios/MessagesShare.h
@@ -50,5 +50,7 @@
 #import <MessageUI/MFMessageComposeViewController.h>
 @interface MessagesShare : NSObject <MFMessageComposeViewControllerDelegate>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+@property (nonatomic, strong) MFMessageComposeViewController *composeVC;
+
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end

--- a/ios/MessagesShare.m
+++ b/ios/MessagesShare.m
@@ -9,7 +9,6 @@
 #import <MessageUI/MFMessageComposeViewController.h>
 
 @implementation MessagesShare
-static MFMessageComposeViewController *composeVC;
 
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
@@ -21,9 +20,10 @@ static MFMessageComposeViewController *composeVC;
        NSLog(@"Message services are not available.");
     }
 
+    
     dispatch_async(dispatch_get_main_queue(), ^{
-        composeVC = [[MFMessageComposeViewController alloc] init];
-        composeVC.messageComposeDelegate = self;
+        self.composeVC = [[MFMessageComposeViewController alloc] init];
+        self.composeVC.messageComposeDelegate = self;
          
         if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
             // Configure the fields of the interface.
@@ -31,12 +31,12 @@ static MFMessageComposeViewController *composeVC;
             if ([options objectForKey:@"url"] && [options objectForKey:@"url"] != [NSNull null]) {
                 text = [text stringByAppendingString: [@" " stringByAppendingString: [RCTConvert NSString:options[@"url"]]] ];
             }
-            composeVC.body = text;
+            self.composeVC.body = text;
         }
          
         // Present the view controller modally.
         UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-        [ctrl presentViewController:composeVC animated:YES completion:nil];
+        [ctrl presentViewController:self.composeVC animated:YES completion:nil];
 
         successCallback(@[]);
     });

--- a/ios/RNShare.h
+++ b/ios/RNShare.h
@@ -8,6 +8,10 @@
 #import "React/RCTBridgeModule.h"   // Required when used as a Pod in a Swift project
 #endif
 
+#import "MessagesShare.h"
+
 @interface RNShare : NSObject <RCTBridgeModule>
+
+@property (nonatomic, strong) MessagesShare *messagesShareCtl;
 
 @end

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -55,6 +55,15 @@
 }
 RCT_EXPORT_MODULE()
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.messagesShareCtl = [[MessagesShare alloc] init];
+    }
+    return self;
+}
+
 RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
                   failureCallback:(RCTResponseErrorBlock)failureCallback
                   successCallback:(RCTResponseSenderBlock)successCallback)
@@ -93,8 +102,7 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
         } else if([social isEqualToString:@"messages"]) {
             NSLog(@"TRY OPEN messages");
-            MessagesShare *shareCtl = [[MessagesShare alloc] init];
-            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+            [self.messagesShareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
         } else {
             failureCallback(@"unsupported platform supplied to shareSingle");
         }

--- a/ios/WhatsAppShare.h
+++ b/ios/WhatsAppShare.h
@@ -49,5 +49,5 @@
 #endif
 @interface WhatsAppShare : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+- (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
 @end


### PR DESCRIPTION
- Fix void pointer in header file
- Fix nil delegate

Tip: in de andere share classes worden vaak dingen met UI gedaan zonder dat dit op de main thread gebeurd, kan rare crashes en gedrag opleveren: https://developer.apple.com/documentation/code_diagnostics/main_thread_checker